### PR TITLE
The logging level could not be set.

### DIFF
--- a/SRTHaishinKit/Sources/SRT/SRTLogger.swift
+++ b/SRTHaishinKit/Sources/SRT/SRTLogger.swift
@@ -29,6 +29,7 @@ public enum SRTLogLevel: Sendable {
     }
 }
 
+/// Constants that indicate the addition to levels the logging system has functional areas .
 public enum SRTLogFunctionalArea: Int32, Sendable {
     /// General uncategorized log, for serious issues only
     case general = 0
@@ -96,16 +97,17 @@ public enum SRTLogFunctionalArea: Int32, Sendable {
     }
 }
 
-///  An object for writing interpolated string messages to srt logging system.
-public struct SRTLogger: Sendable {
+/// An actor for writing interpolated string messages to srt logging system.
+public actor SRTLogger {
+    /// The singleton logger instance.
     public static let shared = SRTLogger()
 
     private init() {
         srt_setloglevel(level.value)
     }
 
-    /// Specifies the current logging level.
-    public var level: SRTLogLevel = .notice {
+    /// The current logging level.
+    public private(set) var level: SRTLogLevel = .notice {
         didSet {
             guard level != oldValue else {
                 return
@@ -114,8 +116,8 @@ public struct SRTLogger: Sendable {
         }
     }
 
-    /// Specifies the current logging functional areas.
-    public var functionalAreas: Set<SRTLogFunctionalArea> = [] {
+    /// The current logging functional areas.
+    public private(set) var functionalAreas: Set<SRTLogFunctionalArea> = [] {
         didSet {
             for area in oldValue.subtracting(functionalAreas) {
                 area.delLogFA()
@@ -124,5 +126,15 @@ public struct SRTLogger: Sendable {
                 area.addLogFA()
             }
         }
+    }
+
+    /// Sets the current logging level.
+    public func setLavel(_ level: SRTLogLevel) {
+        self.level = level
+    }
+
+    /// Sets the current logging functional areas.
+    public func setFunctionalAreas(_ functionalAreas: Set<SRTLogFunctionalArea>) {
+        self.functionalAreas = functionalAreas
     }
 }

--- a/SRTHaishinKit/Sources/SRT/SRTSocket.swift
+++ b/SRTHaishinKit/Sources/SRT/SRTSocket.swift
@@ -176,14 +176,6 @@ final actor SRTSocket {
         }
     }
 
-    func getOption(_ option: SRTSocketOption) throws -> String? {
-        return String(data: try option.getOption(socket), encoding: .ascii)
-    }
-
-    private func getOption(_ option: SRTSocketOption) throws -> Data {
-        return try option.getOption(socket)
-    }
-
     private func configure(_ binding: SRTSocketOption.Binding) -> Bool {
         let failures = SRTSocketOption.configure(socket, binding: binding, options: options)
         guard failures.isEmpty else {


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
Fixed an issue where the logging API could not be configured in the 2.0.x series.
```swift
await SRTLogger.shared.setLevel(.notice)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots:

