### PR TITLE
Modified to use blocking processing while the listener is waiting.

### DIFF
--- a/SRTHaishinKit/Sources/SRT/SRTStream.swift
+++ b/SRTHaishinKit/Sources/SRT/SRTStream.swift
@@ -9,8 +9,6 @@ public actor SRTStream {
     @Published public private(set) var readyState: HKStreamReadyState = .idle
     public private(set) var videoTrackId: UInt8? = UInt8.max
     public private(set) var audioTrackId: UInt8? = UInt8.max
-    private var name: String?
-    private var action: (() async -> Void)?
     private var outputs: [any HKStreamOutput] = []
     private var bitrateStorategy: (any HKStreamBitRateStrategy)?
     private lazy var writer = TSWriter()
@@ -30,8 +28,13 @@ public actor SRTStream {
     }
 
     /// Sends streaming audio and video from client.
+    ///
+    /// - Warning: As a prerequisite, SRTConnection must be connected. In the future, an exception will be thrown.
     public func publish(_ name: String? = "") async {
-        guard let name else {
+        guard let connection, await connection.connected else {
+            return
+        }
+        guard name != nil else {
             switch readyState {
             case .publishing:
                 await close()
@@ -40,43 +43,43 @@ public actor SRTStream {
             }
             return
         }
-        if await connection?.connected == true {
-            readyState = .publishing
-            outgoing.startRunning()
-            if outgoing.videoInputFormat != nil {
-                writer.expectedMedias.insert(.video)
+        readyState = .publishing
+        outgoing.startRunning()
+        if outgoing.videoInputFormat != nil {
+            writer.expectedMedias.insert(.video)
+        }
+        if outgoing.audioInputFormat != nil {
+            writer.expectedMedias.insert(.audio)
+        }
+        Task {
+            for await buffer in outgoing.videoOutputStream {
+                append(buffer)
             }
-            if outgoing.audioInputFormat != nil {
-                writer.expectedMedias.insert(.audio)
+        }
+        Task {
+            for await buffer in outgoing.audioOutputStream {
+                append(buffer.0, when: buffer.1)
             }
-            Task {
-                for await buffer in outgoing.videoOutputStream {
-                    append(buffer)
-                }
+        }
+        Task {
+            for await buffer in outgoing.videoInputStream {
+                outgoing.append(video: buffer)
             }
-            Task {
-                for await buffer in outgoing.audioOutputStream {
-                    append(buffer.0, when: buffer.1)
-                }
+        }
+        Task {
+            for await data in writer.output {
+                await connection.send(data)
             }
-            Task {
-                for await buffer in outgoing.videoInputStream {
-                    outgoing.append(video: buffer)
-                }
-            }
-            Task {
-                for await data in writer.output {
-                    await connection?.send(data)
-                }
-            }
-        } else {
-            action = { [weak self] in await self?.publish(name) }
         }
     }
 
     /// Playback streaming audio and video from server.
-    public func play(_ name: String? = "") async {
-        guard let name else {
+    /// - Warning: As a prerequisite, SRTConnection must be connected. In the future, an exception will be thrown.
+    public func play(_ name: String? = "") async throws {
+        guard let connection, await connection.connected else {
+            return
+        }
+        guard name != nil else {
             switch readyState {
             case .playing:
                 await close()
@@ -85,18 +88,14 @@ public actor SRTStream {
             }
             return
         }
-        if await connection?.connected == true {
-            await connection?.recv()
-            Task {
-                await incoming.startRunning()
-                for await buffer in reader.output {
-                    await incoming.append(buffer.1)
-                }
+        await connection.recv()
+        Task {
+            await incoming.startRunning()
+            for await buffer in reader.output {
+                await incoming.append(buffer.1)
             }
-            readyState = .playing
-        } else {
-            action = { [weak self] in await self?.play(name) }
         }
+        readyState = .playing
     }
 
     /// Stops playing or publishing and makes available other uses.
@@ -107,7 +106,6 @@ public actor SRTStream {
         writer.clear()
         reader.clear()
         outgoing.stopRunning()
-        action = nil
         Task { await incoming.stopRunning() }
         readyState = .idle
     }

--- a/SRTHaishinKit/Tests/SRT/SRTConnectionTests.swift
+++ b/SRTHaishinKit/Tests/SRT/SRTConnectionTests.swift
@@ -6,18 +6,21 @@ import libsrt
 
 @Suite struct SRTConnectionTests {
     @Test func streamid_success() async throws {
-        let listener = SRTConnection()
-        try await listener.connect(URL(string: "srt://:10000?streamid=test"))
+        Task {
+            let listener = SRTConnection()
+            try await listener.connect(URL(string: "srt://:10000?streamid=test"))
+        }
         let connection = SRTConnection()
         try await connection.connect(URL(string: "srt://127.0.0.1:10000?streamid=test"))
         await connection.close()
-        await listener.close()
     }
 
     // Flaky Test.
-    func streamid_failed_success() async throws {
-        let listener = SRTConnection()
-        try await listener.connect(URL(string: "srt://:10001?streamid=test&passphrase=a546994dbf25a0823f0cbadff9cc5088k9e7c2027e8e40933a04ef574bc61cd4a"))
+    @Test func streamid_failed_success() async throws {
+        Task {
+            let listener = SRTConnection()
+            try await listener.connect(URL(string: "srt://:10001?streamid=test&passphrase=a546994dbf25a0823f0cbadff9cc5088k9e7c2027e8e40933a04ef574bc61cd4a"))
+        }
         let connection1 = SRTConnection()
         await #expect(throws: SRTError.self) {
             try await connection1.connect(URL(string: "srt://127.0.0.1:10001?streamid=test2&passphrase=a546994dbf25a0823f0cbadff9cc5088k9e7c2027e8e40933a04ef574bc61cd4"))
@@ -27,6 +30,5 @@ import libsrt
         await #expect(connection2.connected == true)
         await connection1.close()
         await connection2.close()
-        await listener.close()
     }
 }


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation
- The behavior of the SRT listener has also become a blocking process during connection, just like the caller.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

