### PR TITLE
feat(Project): fix retain

### DIFF
--- a/SRTHaishinKit/Sources/SRT/SRTSocket.swift
+++ b/SRTHaishinKit/Sources/SRT/SRTSocket.swift
@@ -219,6 +219,10 @@ final actor SRTSocket {
             return srt_recvmsg(socket, buffer, windowSizeC)
         }
     }
+    
+    deinit {
+        print("⚔️ deinit -> \(String(describing: self))")
+    }
 }
 
 extension SRTSocket: AsyncRunner {


### PR DESCRIPTION
- fix retain for publish flow
- store async stream tasks and cancel it when disconnect

- it prevents frame duplication errors when, after reconnecting, we get a stream delay

- i have not checked the play stream flow, but I think it has the same problem with the async stream

test flow:

    private var connection: SRTConnection?
    private var stream: SRTStream?
    private var mixer: MediaMixer?

    func start() {
        let connection = SRTConnection()
        self.stream = SRTStream(connection: connection)
        self.mixer = MediaMixer(useManualCapture: true)
        self.connection = connection
        Task {
            do {
                guard let stream else { return }
                await mixer?.startRunning()
                await mixer?.addOutput(stream)
                try await connection.connect(URL(string: url))
                await stream.publish(name)
                _isRunning = true
            } catch {
                _isRunning = false
            }
        }
    }

    func stop() {
        Task {
            await mixer?.stopRunning()
            await connection?.close()
            await stream?.close()

            self.mixer = nil
            self.stream = nil
            self.connection = nil
            _isRunning = false
        }
    }

no we have proper object deinit

⚔️ deinit -> SRTHaishinKit.SRTSocket
⚔️ deinit -> SRTHaishinKit.SRTStream
⚔️ deinit -> SRTHaishinKit.SRTConnection


