### PR TITLE
Changing code access protection to RTMPSocket.Error, to make it available for better client handling

### DIFF
--- a/HaishinKit/Sources/RTMP/RTMPSocket.swift
+++ b/HaishinKit/Sources/RTMP/RTMPSocket.swift
@@ -1,10 +1,10 @@
 import Foundation
 import Network
 
-final actor RTMPSocket {
+public final actor RTMPSocket {
     static let defaultWindowSizeC = Int(UInt8.max)
 
-    enum Error: Swift.Error {
+    public enum Error: Swift.Error {
         case invalidState
         case endOfStream
         case connectionTimedOut
@@ -48,7 +48,7 @@ final actor RTMPSocket {
         }
     }
 
-    func connect(_ name: String, port: Int) async throws {
+    internal func connect(_ name: String, port: Int) async throws {
         guard !connected else {
             throw Error.invalidState
         }
@@ -82,7 +82,7 @@ final actor RTMPSocket {
         }
     }
 
-    func send(_ data: Data) {
+    internal func send(_ data: Data) {
         guard connected else {
             return
         }
@@ -90,7 +90,7 @@ final actor RTMPSocket {
         outputs?.yield(data)
     }
 
-    func send(_ iterator: AnyIterator<Data>) {
+    internal func send(_ iterator: AnyIterator<Data>) {
         guard connected else {
             return
         }
@@ -100,7 +100,7 @@ final actor RTMPSocket {
         }
     }
 
-    func recv() -> AsyncStream<Data> {
+    internal func recv() -> AsyncStream<Data> {
         AsyncStream<Data> { continuation in
             Task {
                 do {
@@ -116,7 +116,7 @@ final actor RTMPSocket {
         }
     }
 
-    func close(_ error: NWError? = nil) {
+    internal func close(_ error: NWError? = nil) {
         guard connection != nil else {
             return
         }
@@ -210,11 +210,11 @@ final actor RTMPSocket {
 
 extension RTMPSocket: NetworkTransportReporter {
     // MARK: NetworkTransportReporter
-    func makeNetworkMonitor() async -> NetworkMonitor {
+    public func makeNetworkMonitor() async -> NetworkMonitor {
         return .init(self)
     }
 
-    func makeNetworkTransportReport() -> NetworkTransportReport {
+    public func makeNetworkTransportReport() -> NetworkTransportReport {
         return .init(queueBytesOut: queueBytesOut, totalBytesIn: totalBytesIn, totalBytesOut: totalBytesOut)
     }
 }


### PR DESCRIPTION
## Description & motivation

Currently the RTMPSocket.Error cannot be properly handled by the client, due to its internal protection, this change makes the client able to react and handle the error more gracefully...

for example to extract/handle the core error, or provide custom UI messaging and handling

```
        if let e = rtmpError as? RTMPSocket.Error {
            switch e {
            case .connectionNotEstablished(let error):
                if let error {
                    //...
                }
            default:
                break
            }
        }
```

Follow up to https://github.com/HaishinKit/HaishinKit.swift/discussions/1698

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

