### PR TITLE
Changing AVAudioPCMBuffer+Extension.swift access from internal to public

### DIFF
--- a/HaishinKit/Sources/Extension/AVAudioPCMBuffer+Extension.swift
+++ b/HaishinKit/Sources/Extension/AVAudioPCMBuffer+Extension.swift
@@ -1,7 +1,7 @@
 import Accelerate
 import AVFoundation
 
-extension AVAudioPCMBuffer {
+public extension AVAudioPCMBuffer {
     final func makeSampleBuffer(_ when: AVAudioTime) -> CMSampleBuffer? {
         var status: OSStatus = noErr
         var sampleBuffer: CMSampleBuffer?


### PR DESCRIPTION
## Description & motivation

This is a very handy utility for general use, when making and handling custom output

```
    nonisolated public func mixer(_ mixer: MediaMixer, didOutput buffer: AVAudioPCMBuffer, when: AVAudioTime) {
        guard let sampleBuffer = buffer.makeSampleBuffer(when) else {
            return
        }
        Task {
            coreRecorder.externalCaptureDidOutputSampleBuffer(sampleBuffer, isVideo: false)
        }
    }
```

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:

