### PR TITLE
Fixed for multi channel mixer works well with Xcode16.3

### DIFF
--- a/Examples/iOS/IngestViewController.swift
+++ b/Examples/iOS/IngestViewController.swift
@@ -24,7 +24,7 @@ final class IngestViewController: UIViewController {
     private var retryCount: Int = 0
     private var preferedStereo = false
     private let netStreamSwitcher: HKStreamSwitcher = .init()
-    private lazy var mixer = MediaMixer(multiCamSessionEnabled: true, multiTrackAudioMixingEnabled: false, useManualCapture: true)
+    private lazy var mixer = MediaMixer(multiCamSessionEnabled: true, multiTrackAudioMixingEnabled: true, useManualCapture: true)
     private lazy var audioCapture: AudioCapture = {
         let audioCapture = AudioCapture()
         audioCapture.delegate = self

--- a/HaishinKit/Sources/Mixer/AudioNode.swift
+++ b/HaishinKit/Sources/Mixer/AudioNode.swift
@@ -135,7 +135,16 @@ final class MixerNode: AudioNode {
         componentFlagsMask: 0)
 
     init(format: AVAudioFormat) throws {
-        try super.init(description: &mixerComponentDescription)
+        var mixerDefaultDesc = AudioComponentDescription(
+            componentType: kAudioUnitType_Mixer,
+            componentSubType: kAudioUnitSubType_MultiChannelMixer,
+            componentManufacturer: kAudioUnitManufacturer_Apple,
+            componentFlags: 0,
+            componentFlagsMask: 0)
+        
+        try super.init(description: &mixerDefaultDesc)
+        
+        self.mixerComponentDescription = mixerDefaultDesc
     }
 
     func update(inputCallback: inout AURenderCallbackStruct, bus: UInt8) throws {
@@ -231,7 +240,17 @@ final class OutputNode: AudioNode {
             throw Error.unableToAllocateBuffer
         }
         self.buffer = buffer
-        try super.init(description: &outputComponentDescription)
+        
+        var outputDefaultDesc = AudioComponentDescription(
+            componentType: kAudioUnitType_Output,
+            componentSubType: kAudioUnitSubType_GenericOutput,
+            componentManufacturer: kAudioUnitManufacturer_Apple,
+            componentFlags: 0,
+            componentFlagsMask: 0)
+        
+        try super.init(description: &outputDefaultDesc)
+        
+        self.outputComponentDescription = outputDefaultDesc
     }
 
     func render(numberOfFrames: AVAudioFrameCount,


### PR DESCRIPTION
## Description & motivation

First of all, Thank you so much about you and your frameworks.

I'm using multi channel mixer mode from 1.8.x

It works well until Xcode 16.2, but it occurs runtime error with Xcode 16.3
(Seems MixerNode and OutputNode released so fast than expected - I assumed some kind of Swift runtime bug so I posted to [swift.org forums](https://forums.swift.org/t/different-instance-life-cycle-with-inout-between-xcode16-2-and-16-3/79631) )

To occur, just change multiTrackAudioMixingEnabled flags to true at 27th line in IngestViewController with Xcode 16.3

I fixed MixerNode description values as local value for inout arguments, to avoid runtime BAD_ACCESS_ERROR.

## Type of change
- Bug fix (non-breaking change which fixes an issue)


I hope it will be helpful.