### PR TITLE
Make cgImage in ImageScreenObject thread-safe using a DispatchQueue

### DIFF
--- a/HaishinKit/Sources/Screen/ScreenObject.swift
+++ b/HaishinKit/Sources/Screen/ScreenObject.swift
@@ -158,12 +158,21 @@ extension ScreenObject: Hashable {
 /// An object that manages offscreen rendering a cgImage source.
 public final class ImageScreenObject: ScreenObject {
     /// Specifies the image.
+    private let queue = DispatchQueue(label: "com.ImageScreenObject.cgImageQueue")
+    private var _cgImage: CGImage?
     public var cgImage: CGImage? {
-        didSet {
-            guard cgImage != oldValue else {
-                return
+        get {
+            return queue.sync {
+                _cgImage
             }
-            invalidateLayout()
+        }
+        set {
+            queue.sync {
+                if _cgImage !== newValue {
+                    _cgImage = newValue
+                }
+            }
+            self.invalidateLayout()
         }
     }
 


### PR DESCRIPTION
The cgImage property in ImageScreenObject is a public variable and can be updated at runtime. In scenarios where it’s frequently modified — such as updating a timestamp image every second (even from a Task { @ScreenActor in }) — thread safety issues can arise, leading to crashes. This change resolves the issue by ensuring cgImage access is thread-safe via a dedicated DispatchQueue.

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)