### PR TITLE
Fix: heap-use-after-free in AudioMixerByMultiTrack

### DIFF
--- a/HaishinKit/Sources/Mixer/AudioMixerByMultiTrack.swift
+++ b/HaishinKit/Sources/Mixer/AudioMixerByMultiTrack.swift
@@ -67,6 +67,15 @@ final class AudioMixerByMultiTrack: AudioMixer {
         return status
     }
 
+    deinit {
+        if let mixerNode = mixerNode {
+            AudioOutputUnitStop(mixerNode.audioUnit)
+        }
+        if let outputNode = outputNode {
+            AudioOutputUnitStop(outputNode.audioUnit)
+        }
+    }
+
     func append(_ track: UInt8, buffer: CMSampleBuffer) {
         if settings.mainTrack == track {
             inSourceFormat = buffer.formatDescription
@@ -91,6 +100,12 @@ final class AudioMixerByMultiTrack: AudioMixer {
     }
 
     private func setupAudioNodes() throws {
+        if let mixerNode {
+            AudioOutputUnitStop(mixerNode.audioUnit)
+        }
+        if let outputNode {
+            AudioOutputUnitStop(outputNode.audioUnit)
+        }
         mixerNode = nil
         outputNode = nil
         guard let outputFormat else {


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

We were running into heap-use-after-free crashes when using multi track audio. (Manually appending audio > create track > tracks didSet > setupAudioNodes > audio unit callback referenced released node)

<details><summary>Details</summary>
<p>

```
=================================================================
==75717==ERROR: AddressSanitizer: heap-use-after-free on address 0x000147c9e050 at pc 0x000118961a7c bp 0x00016b299230 sp 0x00016b299228
READ of size 8 at 0x000147c9e050 thread T7
    #0 0x000118961a78 in HaishinKit.AudioMixerByMultiTrack.(setupAudioNodes in _1B75AA50985510AC74B10C67113ACF2B)() throws -> ()+0x700 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d91a78)
    #1 0x00011895cb84 in HaishinKit.AudioMixerByMultiTrack.(tryToSetupAudioNodes in _1B75AA50985510AC74B10C67113ACF2B)() -> ()+0x1f8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8cb84)
    #2 0x00011895c97c in HaishinKit.AudioMixerByMultiTrack.(tracks in _1B75AA50985510AC74B10C67113ACF2B).didset : Swift.Dictionary<Swift.UInt8, HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>>+0x28 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8c97c)
    #3 0x00011895b858 in HaishinKit.AudioMixerByMultiTrack.(tracks in _1B75AA50985510AC74B10C67113ACF2B).modify : Swift.Dictionary<Swift.UInt8, HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>> with unmangled suffix ".resume.0"+0x28 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8b858)
    #4 0x000118960edc in HaishinKit.AudioMixerByMultiTrack.(track in _1B75AA50985510AC74B10C67113ACF2B)(for: Swift.UInt8) -> Swift.Optional<HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>>+0xc70 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d90edc)
    #5 0x0001189601bc in HaishinKit.AudioMixerByMultiTrack.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> ()+0x214 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d901bc)
    #6 0x000118965584 in protocol witness for HaishinKit.AudioMixer.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> () in conformance HaishinKit.AudioMixerByMultiTrack : HaishinKit.AudioMixer in HaishinKit+0x8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d95584)
    #7 0x00011894c4f8 in HaishinKit.AudioCaptureUnit.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> ()+0xd8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d7c4f8)
    #8 0x0001189ba778 in HaishinKit.MediaMixer.append(_: __C.CMSampleBufferRef, track: Swift.UInt8) -> ()+0x7bc (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3dea778)
    #9 0x00011906c214 in (2) suspend resume partial function for CoreDuo.LiveStream.enqueue(_: __C.CMSampleBufferRef, track: Swift.UInt8) async -> ()+0x128 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x449c214)
    #10 0x0001a0580130 in <redacted>+0x120 (/usr/lib/swift/libswift_Concurrency.dylib:arm64e+0x5c130)

0x000147c9e050 is located 0 bytes inside of 44-byte region [0x000147c9e050,0x000147c9e07c)
freed by thread T7 here:
    #0 0x0001052efe14 in free+0x7c (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Frameworks/libclang_rt.asan_ios_dynamic.dylib:arm64e+0x3be14)
    #1 0x000118990270 in HaishinKit.MixerNode.__deallocating_deinit+0x3c (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3dc0270)
    #2 0x0001934166c4 in <redacted>+0x34 (/usr/lib/swift/libswiftCore.dylib:arm64e+0x3996c4)
    #3 0x000193417638 in <redacted>+0x94 (/usr/lib/swift/libswiftCore.dylib:arm64e+0x39a638)
    #4 0x00011898e700 in HaishinKit.MixerNode.init(format: __C.AVAudioFormat) throws -> HaishinKit.MixerNode+0x3d4 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3dbe700)
    #5 0x00011898e2e0 in HaishinKit.MixerNode.__allocating_init(format: __C.AVAudioFormat) throws -> HaishinKit.MixerNode+0x3c (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3dbe2e0)
    #6 0x000118961968 in HaishinKit.AudioMixerByMultiTrack.(setupAudioNodes in _1B75AA50985510AC74B10C67113ACF2B)() throws -> ()+0x5f0 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d91968)
    #7 0x00011895cb84 in HaishinKit.AudioMixerByMultiTrack.(tryToSetupAudioNodes in _1B75AA50985510AC74B10C67113ACF2B)() -> ()+0x1f8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8cb84)
    #8 0x00011895c97c in HaishinKit.AudioMixerByMultiTrack.(tracks in _1B75AA50985510AC74B10C67113ACF2B).didset : Swift.Dictionary<Swift.UInt8, HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>>+0x28 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8c97c)
    #9 0x00011895b858 in HaishinKit.AudioMixerByMultiTrack.(tracks in _1B75AA50985510AC74B10C67113ACF2B).modify : Swift.Dictionary<Swift.UInt8, HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>> with unmangled suffix ".resume.0"+0x28 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8b858)
    #10 0x000118960edc in HaishinKit.AudioMixerByMultiTrack.(track in _1B75AA50985510AC74B10C67113ACF2B)(for: Swift.UInt8) -> Swift.Optional<HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>>+0xc70 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d90edc)
    #11 0x0001189601bc in HaishinKit.AudioMixerByMultiTrack.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> ()+0x214 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d901bc)
    #12 0x000118965584 in protocol witness for HaishinKit.AudioMixer.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> () in conformance HaishinKit.AudioMixerByMultiTrack : HaishinKit.AudioMixer in HaishinKit+0x8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d95584)
    #13 0x00011894c4f8 in HaishinKit.AudioCaptureUnit.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> ()+0xd8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d7c4f8)
    #14 0x0001189ba778 in HaishinKit.MediaMixer.append(_: __C.CMSampleBufferRef, track: Swift.UInt8) -> ()+0x7bc (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3dea778)
    #15 0x00011906c214 in (2) suspend resume partial function for CoreDuo.LiveStream.enqueue(_: __C.CMSampleBufferRef, track: Swift.UInt8) async -> ()+0x128 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x449c214)
    #16 0x0001a0580130 in <redacted>+0x120 (/usr/lib/swift/libswift_Concurrency.dylib:arm64e+0x5c130)

previously allocated by thread T7 here:
    #0 0x0001052efd20 in malloc+0x78 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Frameworks/libclang_rt.asan_ios_dynamic.dylib:arm64e+0x3bd20)
    #1 0x0001a5345634 in <redacted>+0x60 (/usr/lib/system/libsystem_malloc.dylib:arm64e+0x19634)
    #2 0x000193412924 in <redacted>+0x28 (/usr/lib/swift/libswiftCore.dylib:arm64e+0x395924)
    #3 0x000193412db0 in <redacted>+0x448 (/usr/lib/swift/libswiftCore.dylib:arm64e+0x395db0)
    #4 0x00011898e2d0 in HaishinKit.MixerNode.__allocating_init(format: __C.AVAudioFormat) throws -> HaishinKit.MixerNode+0x2c (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3dbe2d0)
    #5 0x000118961968 in HaishinKit.AudioMixerByMultiTrack.(setupAudioNodes in _1B75AA50985510AC74B10C67113ACF2B)() throws -> ()+0x5f0 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d91968)
    #6 0x00011895cb84 in HaishinKit.AudioMixerByMultiTrack.(tryToSetupAudioNodes in _1B75AA50985510AC74B10C67113ACF2B)() -> ()+0x1f8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8cb84)
    #7 0x00011895c97c in HaishinKit.AudioMixerByMultiTrack.(tracks in _1B75AA50985510AC74B10C67113ACF2B).didset : Swift.Dictionary<Swift.UInt8, HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>>+0x28 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8c97c)
    #8 0x00011895b858 in HaishinKit.AudioMixerByMultiTrack.(tracks in _1B75AA50985510AC74B10C67113ACF2B).modify : Swift.Dictionary<Swift.UInt8, HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>> with unmangled suffix ".resume.0"+0x28 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d8b858)
    #9 0x000118960edc in HaishinKit.AudioMixerByMultiTrack.(track in _1B75AA50985510AC74B10C67113ACF2B)(for: Swift.UInt8) -> Swift.Optional<HaishinKit.AudioMixerTrack<HaishinKit.AudioMixerByMultiTrack>>+0xc70 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d90edc)
    #10 0x0001189601bc in HaishinKit.AudioMixerByMultiTrack.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> ()+0x214 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d901bc)
    #11 0x000118965584 in protocol witness for HaishinKit.AudioMixer.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> () in conformance HaishinKit.AudioMixerByMultiTrack : HaishinKit.AudioMixer in HaishinKit+0x8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d95584)
    #12 0x00011894c4f8 in HaishinKit.AudioCaptureUnit.append(_: Swift.UInt8, buffer: __C.CMSampleBufferRef) -> ()+0xd8 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d7c4f8)
    #13 0x0001189ba778 in HaishinKit.MediaMixer.append(_: __C.CMSampleBufferRef, track: Swift.UInt8) -> ()+0x7bc (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3dea778)
    #14 0x00011906c214 in (2) suspend resume partial function for CoreDuo.LiveStream.enqueue(_: __C.CMSampleBufferRef, track: Swift.UInt8) async -> ()+0x128 (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x449c214)
    #15 0x0001a0580130 in <redacted>+0x120 (/usr/lib/swift/libswift_Concurrency.dylib:arm64e+0x5c130)

Thread T7 created by T6 here:
    <empty stack>

Thread T6 created by T1 here:
    <empty stack>

Thread T1 created by T0 here:
    <empty stack>

SUMMARY: AddressSanitizer: heap-use-after-free (/private/var/containers/Bundle/Application/D7FB3621-F5E2-4B90-9B85-6DA21D51DC00/Detail.app/Detail.debug.dylib:arm64+0x3d91a78) in HaishinKit.AudioMixerByMultiTrack.(setupAudioNodes in _1B75AA50985510AC74B10C67113ACF2B)() throws -> ()+0x700
Shadow bytes around the buggy address:
  0x000147c9dd80: fa fa fa fa fa fa fa fa fa fa 00 00 00 00 00 00
  0x000147c9de00: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fd
  0x000147c9de80: fa fa fd fd fd fd fd fd fa fa 00 00 00 00 00 fa
  0x000147c9df00: fa fa 00 00 00 00 00 00 fa fa fd fd fd fd fd fa
  0x000147c9df80: fa fa fd fd fd fd fd fd fa fa fd fd fd fd fd fd
=>0x000147c9e000: fa fa fd fd fd fd fd fd fa fa[fd]fd fd fd fd fd
  0x000147c9e080: fa fa 00 00 00 00 00 00 fa fa fd fd fd fd fd fd
  0x000147c9e100: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 00 00
  0x000147c9e180: fa fa 00 00 00 00 00 00 fa fa fd fd fd fd fd fd
  0x000147c9e200: fa fa fa fa fa fa fa fa fa fa fd fd fd fd fd fd
  0x000147c9e280: fa fa fd fd fd fd fd fd fa fa 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==75717==ABORTING
```

</p>
</details> 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)