### PR TITLE
Feature: add new property to allow mirror the preview view

### DIFF
--- a/Sources/IO/MTHKView.swift
+++ b/Sources/IO/MTHKView.swift
@@ -45,6 +45,9 @@ public class MTHKView: MTKView {
         }
     }
 
+    /// Specifies the preview is mirror or not. Default value is `false`
+    public var isMirrored: Bool = false
+
     private var displayImage: CIImage?
     private lazy var commandQueue: (any MTLCommandQueue)? = {
         return device?.makeCommandQueue()
@@ -136,6 +139,14 @@ public class MTHKView: MTKView {
         }
 
         var scaledImage = displayImage
+
+        if isMirrored {
+            let mirror = CGAffineTransform(scaleX: -1, y: 1)
+                .translatedBy(x: -scaledImage.extent.width, y: 0)
+            scaledImage = scaledImage.transformed(by: mirror)
+        }
+
+        scaledImage = scaledImage
             .transformed(by: CGAffineTransform(translationX: translationX, y: translationY))
             .transformed(by: CGAffineTransform(scaleX: scaleX, y: scaleY))
 


### PR DESCRIPTION

## Description & motivation

I use front camera for live-stream, but the text will be mirrored if I set `            videoUnit.isVideoMirrored = isFrontCamera`. I want to have an option to mirror the preview only, the output will keep the correct data from camera.

## Type of change
Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

## Screenshots:
<img width="1051" alt="Screenshot 2025-06-02 at 17 03 51" src="https://github.com/user-attachments/assets/1e0483b3-dd5a-4116-aee2-d8ac949b361a" />
<img width="1009" alt="Screenshot 2025-06-02 at 17 04 08" src="https://github.com/user-attachments/assets/dc8ccba0-85ac-43e0-989a-3d1d49cb888b" />

