### PR TITLE
#1732: Fix audio timestamps when audio source discontinues.

### DIFF
--- a/HaishinKit/Sources/Codec/AudioCodec.swift
+++ b/HaishinKit/Sources/Codec/AudioCodec.swift
@@ -170,6 +170,7 @@ final class AudioCodec {
         if logger.isEnabledFor(level: .info) {
             logger.info("converter:", converter ?? "nil", ",inputFormat:", inputFormat, ",outputFormat:", outputFormat)
         }
+        audioTime.reset()
         return converter
     }
 }

--- a/HaishinKit/Sources/Util/AudioTime.swift
+++ b/HaishinKit/Sources/Util/AudioTime.swift
@@ -43,7 +43,7 @@ final class AudioTime {
             return
         }
         sampleRate = time.sampleRate
-        sampleTime = 0
+        sampleTime = time.sampleTime
         anchorTime = time
     }
 


### PR DESCRIPTION
## Description & motivation

Fix timestamps in RTMP packets remain continuous, even when audio source is discontinuous (has gaps). This lead to lip-sync problems.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Explanation
The reset of the audio timeline when audio codec re-creates audio converter is required to pick new anchor time of next audio sample.
The anchor time update should also pick the current sample from provided anchor time, otherwise extrapolate time will jump forward or backward when computing new timestamp.

## Corner case
This fixes the case when switch between devices which has different audio formats (e.g sample rate), which causes reset of `AudioCodec`. When two BT devices has sample format, but different clock this fix is not enough. There should be other way to trigger `AudioCodec` state reset.

## Screenshots:
