### PR TITLE
Fix: Check of input buffer capacity, not the current length.

### DIFF
--- a/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
+++ b/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
@@ -21,6 +21,11 @@ final class AudioRingBuffer {
     private var sampleTime: AVAudioFramePosition = 0
     private var inputFormat: AVAudioFormat
     private var inputBuffer: AVAudioPCMBuffer
+#if DEBUG
+    var testableInputBuffer: AVAudioPCMBuffer {
+      inputBuffer
+    }
+#endif
     private var outputBuffer: AVAudioPCMBuffer
 
     init?(_ inputFormat: AVAudioFormat, bufferCounts: UInt32 = AudioRingBuffer.bufferCounts) {

--- a/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
+++ b/HaishinKit/Sources/Mixer/AudioRingBuffer.swift
@@ -54,7 +54,7 @@ final class AudioRingBuffer {
         if sampleTime == 0 {
             sampleTime = targetSampleTime
         }
-        if inputBuffer.frameLength < sampleBuffer.numSamples {
+        if inputBuffer.frameCapacity < sampleBuffer.numSamples {
             if let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: AVAudioFrameCount(sampleBuffer.numSamples)) {
                 self.inputBuffer = buffer
             }
@@ -87,7 +87,7 @@ final class AudioRingBuffer {
         if sampleTime == 0 {
             sampleTime = when.sampleTime
         }
-        if inputBuffer.frameLength < audioPCMBuffer.frameLength {
+        if inputBuffer.frameCapacity < audioPCMBuffer.frameLength {
             if let buffer = AVAudioPCMBuffer(pcmFormat: inputFormat, frameCapacity: audioPCMBuffer.frameCapacity) {
                 self.inputBuffer = buffer
             }

--- a/HaishinKit/Tests/Mixer/AudioRingBufferTests.swift
+++ b/HaishinKit/Tests/Mixer/AudioRingBufferTests.swift
@@ -21,6 +21,29 @@ import Testing
         try appendSampleBuffer(1024, channels: 2)
     }
 
+    @Test func reusesInputBufferWhenCapacityIsSufficient() throws {
+        let audioFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 48000, channels: 1, interleaved: true)!
+        let ringBuffer = AudioRingBuffer(audioFormat, bufferCounts: 3)!
+        let initialInternalPCMBuff = ringBuffer.testableInputBuffer
+        let buffer1 = AVAudioPCMBuffer(pcmFormat: audioFormat, frameCapacity: 1)!
+        buffer1.frameLength = 1
+        ringBuffer.append(buffer1, when: .init(sampleTime: 0, atRate: 48000))
+
+        #expect(initialInternalPCMBuff === ringBuffer.testableInputBuffer)
+    }
+
+    @Test func reallocatesInputBufferWhenCapacityIsInsufficient() throws {
+        let audioFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 48000, channels: 1, interleaved: true)!
+        let ringBuffer = AudioRingBuffer(audioFormat, bufferCounts: 3)!
+        let initialInternalPCMBuff = ringBuffer.testableInputBuffer
+        let buffer1 = AVAudioPCMBuffer(pcmFormat: audioFormat, frameCapacity: initialInternalPCMBuff.frameCapacity + 1)!
+        buffer1.frameLength = buffer1.frameCapacity
+        ringBuffer.append(buffer1, when: .init(sampleTime: 0, atRate: 48000))
+
+        #expect(initialInternalPCMBuff !== ringBuffer.testableInputBuffer)
+        #expect(ringBuffer.testableInputBuffer.frameCapacity == buffer1.frameCapacity)
+    }
+
     private func appendSampleBuffer(_ numSamples: Int, channels: UInt32) throws {
         var asbd = AudioStreamBasicDescription(
             mSampleRate: 44100,


### PR DESCRIPTION
The input buffer can store appended buffer if it's capacity greater than or equal of amount of input. This reduces amount of allocations of audio buffers when appended buffers frequently changes `frameLength`.

<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

## Description & motivation

The appended buffer could be written into the `inputBuffer` in case of `inputBuffer` has enough capacity, it does not matter how many samples were presented in the buffer before (aka `frameLength`).

## Type of change
Please delete options that are not relevant.
- [ ] Enhancement (non-breaking change which fixes an issue)

## Screenshots:
