### PR TITLE
Support for rtmp url's query parameters

### DIFF
--- a/HaishinKit/Sources/Docs.docc/index.md
+++ b/HaishinKit/Sources/Docs.docc/index.md
@@ -65,11 +65,14 @@ Task {
 ```
 
 #### Make Session
+**RTMP**
+Please provide the RTMP connection URL combined with the streamName.
 ```swift
-let session = try await SessionBuilderFactory.shared.make(URL(string: "rtmp://hostname/live/live"))
+let session = try await SessionBuilderFactory.shared.make(URL(string: "rtmp://hostname/appName/stramName"))
   .setMode(.ingest)
   .build()
 ```
+**SRT**
 ```swift
 let session = try await SessionBuilderFactory.shared.make(URL(string: "srt://hostname:448?stream=xxxxx"))
   .setMode(.playback)

--- a/RTMPHaishinKit/Sources/RTMP/RTMPURL.swift
+++ b/RTMPHaishinKit/Sources/RTMP/RTMPURL.swift
@@ -7,7 +7,11 @@ struct RTMPURL {
         var pathComponents = url.pathComponents
         pathComponents.removeFirst()
         pathComponents.removeFirst()
-        return pathComponents.joined(separator: "/")
+        if let query = URLComponents(url: url, resolvingAgainstBaseURL: false)?.query {
+            return pathComponents.joined(separator: "/") + "?" + query
+        } else {
+            return pathComponents.joined(separator: "/")
+        }
     }
 
     var command: String {

--- a/RTMPHaishinKit/Tests/RTMP/RTMPConnectionTests.swift
+++ b/RTMPHaishinKit/Tests/RTMP/RTMPConnectionTests.swift
@@ -8,7 +8,7 @@ import Testing
         weak var weakConnection: RTMPConnection?
         _ = try? await {
             let connection = RTMPConnection()
-            _ = try await connection.connect("rtmp://localhost:1935/live")
+            _ = try await connection.connect("rtmp://192.168.0.0:1935/live")
             try await connection.close()
             weakConnection = connection
         }()

--- a/RTMPHaishinKit/Tests/RTMP/RTMPURLTests.swift
+++ b/RTMPHaishinKit/Tests/RTMP/RTMPURLTests.swift
@@ -10,4 +10,10 @@ import Testing
         #expect(url.streamName == "live")
         #expect(url.command == "rtmp://localhost/live")
     }
+
+    @Test func query() {
+        let url = RTMPURL(url: URL(string: "rtmp://localhost/live/live?parameter")!)
+        #expect(url.streamName == "live?parameter")
+        #expect(url.command == "rtmp://localhost/live")
+    }
 }


### PR DESCRIPTION
## Description & motivation
- fixed https://github.com/HaishinKit/HaishinKit.swift/discussions/1786

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots:
