### PR TITLE
Fix out-of-bounds crash on truncated RTMP User Control messages

### DIFF
--- a/RTMPHaishinKit/Sources/RTMP/RTMPMessage.swift
+++ b/RTMPHaishinKit/Sources/RTMP/RTMPMessage.swift
@@ -659,8 +659,21 @@ struct RTMPUserControlMessage: RTMPMessage {
     init(_ header: RTMPChunkMessageHeader) {
         streamId = header.messageStreamId
         timestamp = header.timestamp
-        event = Event(rawValue: header.payload[1]) ?? .unknown
-        value = Int32(data: header.payload[2..<header.payload.count]).bigEndian
+        // A well-formed user control message is at least 6 bytes: a 2-byte
+        // event type followed by a 4-byte value. A truncated payload from the
+        // peer would otherwise index past the end of `payload` and trap
+        // (EXC_BREAKPOINT / out of bounds), crashing the whole process from
+        // the RTMP receive loop. Re-base to a 0-indexed copy (a Data slice
+        // keeps its parent's indices) and bail out to a safe default when the
+        // payload is too short.
+        let payload = Data(header.payload)
+        guard payload.count >= 6 else {
+            event = .unknown
+            value = 0
+            return
+        }
+        event = Event(rawValue: payload[1]) ?? .unknown
+        value = Int32(data: payload[2..<payload.count]).bigEndian
     }
 
     init(event: Event, value: Int32) {

--- a/RTMPHaishinKit/Tests/RTMP/RTMPUserControlMessageTests.swift
+++ b/RTMPHaishinKit/Tests/RTMP/RTMPUserControlMessageTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import RTMPHaishinKit
+
+@Suite struct RTMPUserControlMessageTests {
+    // Regression: a truncated user control message (shorter than the 6-byte
+    // event-type + value layout) must not trap on an out-of-bounds Data
+    // subscript. Before the bounds guard this crashed the process from the
+    // RTMP receive loop (EXC_BREAKPOINT in RTMPUserControlMessage.init).
+    @Test func truncatedPayloadDoesNotCrash() {
+        // messageLength 0 -> empty payload, position 0 == count 0, so
+        // makeMessage() builds the message and runs the (previously
+        // unguarded) decode against an empty buffer.
+        let header = RTMPChunkMessageHeader(
+            timestmap: 0,
+            messageLength: 0,
+            messageTypeId: RTMPMessageType.user.rawValue,
+            messageStreamId: 0
+        )
+        let message = header.makeMessage() as? RTMPUserControlMessage
+        #expect(message?.event == .unknown)
+        #expect(message?.value == 0)
+    }
+
+    // A well-formed 6-byte user control message must still decode correctly
+    // (2-byte event type + 4-byte big-endian value).
+    @Test func wellFormedPayloadDecodes() {
+        let buffer = RTMPChunkBuffer()
+        // basic header (fmt 0, csid 2) | timestamp(3) | length(3)=6 |
+        // typeId(1)=4 | streamId(4) | payload: event 0x0000 (streamBegin),
+        // value 0x00000001.
+        buffer.put(Data([2, 0, 0, 0, 0, 0, 6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]))
+        do {
+            let (chunkType, chunkStreamId) = try buffer.getBasicHeader()
+            #expect(chunkType == .zero)
+            #expect(chunkStreamId == 2)
+            let header = RTMPChunkMessageHeader()
+            try buffer.getMessageHeader(chunkType, messageHeader: header)
+            let message = header.makeMessage() as? RTMPUserControlMessage
+            #expect(message?.event == .streamBegin)
+            #expect(message?.value == 1)
+        } catch {
+            Issue.record("unexpected error decoding user control message: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`RTMPUserControlMessage.init(_:)` decodes a User Control message without validating the payload length:

```swift
event = Event(rawValue: header.payload[1]) ?? .unknown
value = Int32(data: header.payload[2..<header.payload.count]).bigEndian
```

A well-formed User Control message is at least 6 bytes (2-byte event type + 4-byte value). When the peer sends a shorter/truncated message, `payload[1]` / the `2..<count` slice / the 4-byte `Int32` read index past the end of the `Data`, and Swift's bounds check traps:

```
Exception Type:  EXC_BREAKPOINT (SIGTRAP)
Thread N Crashed:
0  Foundation   Data._Representation.subscript.getter
1  …            RTMPUserControlMessage.init(_:) (RTMPMessage.swift)
2  …            RTMPChunkMessageHeader.makeMessage() (RTMPChunk.swift)
3  …            RTMPConnection.listen(_:) (RTMPConnection.swift)
```

Because this is on the `RTMPConnection` receive loop, a single malformed inbound message crashes the entire host process. We hit this in production on a publishing client.

## Fix

Re-base the payload to a 0-indexed copy (a `Data` slice keeps its parent's indices, so even `payload[1]` is unsafe on a non-zero-based slice) and fall back to a safe default (`.unknown` / `0`) when the payload is shorter than the 6-byte layout. Behavior for valid messages is unchanged.

## Tests

Adds `RTMPUserControlMessageTests`:
- `truncatedPayloadDoesNotCrash` — a 0-length user-control payload. Before the fix this test process exits with **signal 5 (SIGTRAP)**; after, it returns `.unknown` / `0`.
- `wellFormedPayloadDecodes` — a valid 6-byte `streamBegin` message still decodes to `event == .streamBegin`, `value == 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)