### PR TITLE
Revert "Serialize mixer output frame ordering via AsyncStream."

### DIFF
--- a/HaishinKit/Sources/Stream/StreamRecorder.swift
+++ b/HaishinKit/Sources/Stream/StreamRecorder.swift
@@ -126,8 +126,6 @@ public actor StreamRecorder {
     private var audioPresentationTime: CMTime = .zero
     private var videoPresentationTime: CMTime = .zero
     private var dimensions: CMVideoDimensions = .init(width: 0, height: 0)
-    nonisolated(unsafe) private var inputContinuation: AsyncStream<CMSampleBuffer>.Continuation?
-    private var inputConsumerTask: Task<Void, Never>?
 
     /// Creates a new recorder.
     public init() {
@@ -193,7 +191,6 @@ public actor StreamRecorder {
         videoPresentationTime = .zero
         audioPresentationTime = .zero
         self.settings = settings
-        startInputConsumer()
 
         isRecording = true
     }
@@ -218,7 +215,6 @@ public actor StreamRecorder {
             throw Error.invalidState
         }
         defer {
-            stopInputConsumer()
             isRecording = false
             continuation = nil
             self.writer = nil
@@ -256,23 +252,6 @@ public actor StreamRecorder {
                 moviesDirectory.appendingPathComponent(url.path)
         }
         return url.pathExtension.isEmpty ? url.appendingPathComponent(UUID().uuidString).appendingPathExtension(Self.defaultPathExtension) : url
-    }
-
-    private func startInputConsumer() {
-        let (stream, continuation) = AsyncStream.makeStream(of: CMSampleBuffer.self)
-        inputContinuation = continuation
-        inputConsumerTask = Task {
-            for await sampleBuffer in stream {
-                append(sampleBuffer)
-            }
-        }
-    }
-
-    private func stopInputConsumer() {
-        inputContinuation?.finish()
-        inputContinuation = nil
-        inputConsumerTask?.cancel()
-        inputConsumerTask = nil
     }
 
     private func append(_ sampleBuffer: CMSampleBuffer) {
@@ -373,27 +352,31 @@ public actor StreamRecorder {
 extension StreamRecorder: StreamOutput {
     // MARK: HKStreamOutput
     nonisolated public func stream(_ stream: some StreamConvertible, didOutput video: CMSampleBuffer) {
-        inputContinuation?.yield(video)
+        Task { await append(video) }
     }
 
     nonisolated public func stream(_ stream: some StreamConvertible, didOutput audio: AVAudioBuffer, when: AVAudioTime) {
         guard let sampleBuffer = (audio as? AVAudioPCMBuffer)?.makeSampleBuffer(when) else {
             return
         }
-        inputContinuation?.yield(sampleBuffer)
+        Task { await append(sampleBuffer) }
     }
 }
 
 extension StreamRecorder: MediaMixerOutput {
     // MARK: MediaMixerOutput
     nonisolated public func mixer(_ mixer: MediaMixer, didOutput sampleBuffer: CMSampleBuffer) {
-        inputContinuation?.yield(sampleBuffer)
+        Task {
+            await append(sampleBuffer)
+        }
     }
 
     nonisolated public func mixer(_ mixer: MediaMixer, didOutput buffer: AVAudioPCMBuffer, when: AVAudioTime) {
         guard let sampleBuffer = buffer.makeSampleBuffer(when) else {
             return
         }
-        inputContinuation?.yield(sampleBuffer)
+        Task {
+            await append(sampleBuffer)
+        }
     }
 }

--- a/RTMPHaishinKit/Sources/RTMP/RTMPStream.swift
+++ b/RTMPHaishinKit/Sources/RTMP/RTMPStream.swift
@@ -224,8 +224,6 @@ public actor RTMPStream {
     private var expectedResponse: Code?
     package var bitRateStrategy: (any StreamBitRateStrategy)?
     private var statusContinuation: AsyncStream<RTMPStatus>.Continuation?
-    nonisolated(unsafe) private var mixerAudioContinuation: AsyncStream<(AVAudioPCMBuffer, AVAudioTime)>.Continuation?
-    nonisolated(unsafe) private var mixerVideoContinuation: AsyncStream<CMSampleBuffer>.Continuation?
     private(set) var id: UInt32 = RTMPStream.defaultID
     package lazy var incoming = IncomingStream(self)
     package lazy var outgoing = OutgoingStream()
@@ -277,7 +275,6 @@ public actor RTMPStream {
         self.fcPublishName = fcPublishName
         self.requestTimeout = connection.requestTimeout
         Task {
-            await self.startMixerInputConsumers()
             await connection.addStream(self)
             if await connection.connected {
                 await createStream()
@@ -286,8 +283,6 @@ public actor RTMPStream {
     }
 
     deinit {
-        mixerAudioContinuation?.finish()
-        mixerVideoContinuation?.finish()
         outputs.removeAll()
     }
 
@@ -393,8 +388,6 @@ public actor RTMPStream {
             readyState = .publishing
             try? send("@setDataFrame", arguments: "onMetaData", metadata)
             outgoing.startRunning()
-            stopMixerInputConsumers()
-            startMixerInputConsumers()
             Task {
                 for await audio in outgoing.audioOutputStream {
                     append(audio.0, when: audio.1)
@@ -422,8 +415,6 @@ public actor RTMPStream {
         guard readyState == .playing || readyState == .publishing else {
             throw Error.invalidState
         }
-        stopMixerInputConsumers()
-        startMixerInputConsumers()
         outgoing.stopRunning()
         return try await withCheckedThrowingContinuation { continutation in
             self.continuation = continutation
@@ -692,30 +683,6 @@ public actor RTMPStream {
         }
     }
 
-    private func startMixerInputConsumers() {
-        let (audioStream, audioContinuation) = AsyncStream.makeStream(of: (AVAudioPCMBuffer, AVAudioTime).self)
-        let (videoStream, videoContinuation) = AsyncStream.makeStream(of: CMSampleBuffer.self)
-        mixerAudioContinuation = audioContinuation
-        mixerVideoContinuation = videoContinuation
-        Task {
-            for await (buffer, when) in audioStream {
-                append(buffer, when: when)
-            }
-        }
-        Task {
-            for await sampleBuffer in videoStream {
-                append(sampleBuffer)
-            }
-        }
-    }
-
-    private func stopMixerInputConsumers() {
-        mixerAudioContinuation?.finish()
-        mixerAudioContinuation = nil
-        mixerVideoContinuation?.finish()
-        mixerVideoContinuation = nil
-    }
-
     /// Creates flv metadata for a stream.
     private func makeMetadata() -> AMFArray {
         // https://github.com/shogo4405/HaishinKit.swift/issues/1410
@@ -839,10 +806,10 @@ extension RTMPStream: MediaMixerOutput {
     }
 
     nonisolated public func mixer(_ mixer: MediaMixer, didOutput sampleBuffer: CMSampleBuffer) {
-        mixerVideoContinuation?.yield(sampleBuffer)
+        Task { await append(sampleBuffer) }
     }
 
     nonisolated public func mixer(_ mixer: MediaMixer, didOutput buffer: AVAudioPCMBuffer, when: AVAudioTime) {
-        mixerAudioContinuation?.yield((buffer, when))
+        Task { await append(buffer, when: when) }
     }
 }

--- a/SRTHaishinKit/Sources/SRT/SRTStream.swift
+++ b/SRTHaishinKit/Sources/SRT/SRTStream.swift
@@ -24,8 +24,6 @@ public actor SRTStream {
     package lazy var incoming = IncomingStream(self)
     package lazy var outgoing = OutgoingStream()
     private weak var connection: SRTConnection?
-    nonisolated(unsafe) private var mixerAudioContinuation: AsyncStream<(AVAudioPCMBuffer, AVAudioTime)>.Continuation?
-    nonisolated(unsafe) private var mixerVideoContinuation: AsyncStream<CMSampleBuffer>.Continuation?
 
     /// The error domain codes.
     public enum Error: Swift.Error {
@@ -36,15 +34,10 @@ public actor SRTStream {
     /// Creates a new stream object.
     public init(connection: SRTConnection) {
         self.connection = connection
-        Task {
-            await self.startMixerInputConsumers()
-            await connection.addStream(self)
-        }
+        Task { await connection.addStream(self) }
     }
 
     deinit {
-        mixerAudioContinuation?.finish()
-        mixerVideoContinuation?.finish()
         outputs.removeAll()
     }
 
@@ -65,8 +58,6 @@ public actor SRTStream {
             return
         }
         readyState = .publishing
-        stopMixerInputConsumers()
-        startMixerInputConsumers()
         outgoing.startRunning()
         if outgoing.videoInputFormat != nil {
             writer.expectedMedias.insert(.video)
@@ -130,8 +121,6 @@ public actor SRTStream {
         guard readyState != .idle else {
             return
         }
-        stopMixerInputConsumers()
-        startMixerInputConsumers()
         writer.clear()
         reader.clear()
         outgoing.stopRunning()
@@ -149,30 +138,6 @@ public actor SRTStream {
 
     func doInput(_ data: Data) {
         _ = reader.read(data)
-    }
-
-    private func startMixerInputConsumers() {
-        let (audioStream, audioContinuation) = AsyncStream.makeStream(of: (AVAudioPCMBuffer, AVAudioTime).self)
-        let (videoStream, videoContinuation) = AsyncStream.makeStream(of: CMSampleBuffer.self)
-        mixerAudioContinuation = audioContinuation
-        mixerVideoContinuation = videoContinuation
-        Task {
-            for await (buffer, when) in audioStream {
-                append(buffer, when: when)
-            }
-        }
-        Task {
-            for await sampleBuffer in videoStream {
-                append(sampleBuffer)
-            }
-        }
-    }
-
-    private func stopMixerInputConsumers() {
-        mixerAudioContinuation?.finish()
-        mixerAudioContinuation = nil
-        mixerVideoContinuation?.finish()
-        mixerVideoContinuation = nil
     }
 }
 
@@ -238,10 +203,10 @@ extension SRTStream: MediaMixerOutput {
     }
 
     nonisolated public func mixer(_ mixer: MediaMixer, didOutput sampleBuffer: CMSampleBuffer) {
-        mixerVideoContinuation?.yield(sampleBuffer)
+        Task { await append(sampleBuffer) }
     }
 
     nonisolated public func mixer(_ mixer: MediaMixer, didOutput buffer: AVAudioPCMBuffer, when: AVAudioTime) {
-        mixerAudioContinuation?.yield((buffer, when))
+        Task { await append(buffer, when: when) }
     }
 }


### PR DESCRIPTION
Reverts HaishinKit/HaishinKit.swift#1890

The performance isn’t good, so I’ll revert it for now.
