### PR TITLE
Fix: concat all IDR/slice NAL units per PES, not just first

### DIFF
--- a/SRTHaishinKit/Sources/TS/TSReader.swift
+++ b/SRTHaishinKit/Sources/TS/TSReader.swift
@@ -114,10 +114,13 @@ final class TSReader {
         switch data.streamType {
         case .h264:
             let units = nalUnitReader.read(&pes.data, type: H264NALUnit.self)
-            if let unit = units.first(where: { $0.type == .idr || $0.type == .slice }) {
-                var data = Data([0x00, 0x00, 0x00, 0x01])
-                data.append(unit.data)
-                pes.data = data
+            var annexB = Data()
+            for unit in units where unit.type == .idr || unit.type == .slice {
+                annexB.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+                annexB.append(unit.data)
+            }
+            if !annexB.isEmpty {
+                pes.data = annexB
             }
             isNotSync = !units.contains { $0.type == .idr }
         case .h265:


### PR DESCRIPTION
## Problem

`TSReader.readPacketizedElementaryStream` keeps only the first IDR/slice NAL unit of
each PES packet:

```swift
if let unit = units.first(where: { $0.type == .idr || $0.type == .slice }) { ... }
```
_SRTHaishinKit/Sources/TS/TSReader.swift at makeSampleBuffer()_

Encoders that emit multiple slices per picture (some hardware H.264 encoders like VideoToolbox on visionOS/iOS screen capture) therefore lose every slice after the first. 
The decoder receives a partial picture, producing corrupted or green/grey bottom bands.

## Fix
Concatenate every IDR/slice NAL unit of the PES into one buffer, preserving order, instead of taking only the first match.

## Notes
- Reproduced using SRT from a visionOS Broadcast Upload Extension (ReplayKit), multi-slice frames decode correctly with this fix.

## Description & motivation
closes #1921 

I wanted to use this repo on visionOS to stream captured video from the user screen and found the bug.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Before:

<img width="1600" height="1240" alt="Image" src="https://github.com/user-attachments/assets/ce4d271d-93e9-4122-8db2-f220b7635a3d" />

After:

<img width="1600" height="1240" alt="Image" src="https://github.com/user-attachments/assets/8b652142-8ad6-43c1-bd6b-8a42c55e07bd" />